### PR TITLE
Maintenance

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,8 @@ name: CI
 on:
   push: 
     branches:
-    - main
+    - '**'
+    - '!dependabot/**'
     tags:
     - 'v[0-9]+\.[0-9]+\.[0-9]+-?**'
   pull_request: {}
@@ -16,8 +17,6 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install cargo binstall
       uses: cargo-bins/cargo-binstall@main
-    - name: Install cargo component
-      run: cargo binstall --force cargo-component
     - name: Install wasm-tools
       run: cargo binstall --force wasm-tools
     - name: Build
@@ -35,7 +34,7 @@ jobs:
       run: git diff --exit-code . ':!lib/'
 
   build-cli:
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/v')
     name: Build CLI
     needs: build
     runs-on: ${{ matrix.os }}
@@ -76,7 +75,7 @@ jobs:
         retention-days: 7
 
   publish:
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'push' && ( startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' )
     needs:
     - build-cli
     permissions:
@@ -90,6 +89,8 @@ jobs:
       uses: cargo-bins/cargo-binstall@main
     - name: Install wkg
       run: cargo binstall --force wkg
+    - name: Install cosign
+      uses: sigstore/cosign-installer@v4.1.2
     - name: Get the version
       id: get_version
       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
@@ -114,6 +115,7 @@ jobs:
     - name: Publish factory to gchr.io
       run: ./publish.sh "ghcr.io/${{ github.repository }}" "${{ steps.get_version.outputs.VERSION }}"
     - name: Draft GitHub Release
+      if: startsWith(github.ref, 'refs/tags/v')
       uses: softprops/action-gh-release@v3
       with:
         draft: true

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Create custom wasi:config components with static values.
 ## Build
 
 Prereqs:
-- a rust toolchain with a recent nightly (`rustup toolchain install nightly`)
-- [`cargo component`](https://github.com/bytecodealliance/cargo-component)
+- a rust toolchain
+- [`wasm-tools`](https://github.com/bytecodealliance/wasm-tools)
 - [`wkg`](https://github.com/bytecodealliance/wasm-pkg-tools)
 
 ```sh

--- a/build.sh
+++ b/build.sh
@@ -13,10 +13,10 @@ mkdir -p "${SCRIPT_DIR}/lib"
 wasm-tools component wit --wasm "${SCRIPT_DIR}/wit" -o "${SCRIPT_DIR}/lib/package.wasm"
 
 cargo build -p adapter --target wasm32-unknown-unknown --release
-cp "${SCRIPT_DIR}/target/wasm32-unknown-unknown/release/adapter.wasm" "${SCRIPT_DIR}/lib"
+cp "${SCRIPT_DIR}/target/wasm32-unknown-unknown/release/adapter.wasm" "${SCRIPT_DIR}/lib/adapter.wasm"
 
-cargo component build -p factory --target wasm32-unknown-unknown --release
-cp "${SCRIPT_DIR}/target/wasm32-unknown-unknown/release/factory.wasm" "${SCRIPT_DIR}/lib"
+cargo build -p factory --target wasm32-unknown-unknown --release
+wasm-tools component new "${SCRIPT_DIR}/target/wasm32-unknown-unknown/release/factory.wasm" -o "${SCRIPT_DIR}/lib/factory.wasm"
 
 cargo build --release
 

--- a/publish.sh
+++ b/publish.sh
@@ -17,14 +17,21 @@ publish_oci() {
     local file="${1}"
     local component=$(basename "${file}" .wasm)
 
-    wkg oci push \
+    digest=$(
+      wkg oci push \
         --annotation "org.opencontainers.image.title=${component}" \
         --annotation "org.opencontainers.image.version=${version}" \
         --annotation "org.opencontainers.image.source=https://github.com/componentized/static-config.git" \
         --annotation "org.opencontainers.image.revision=${revision}" \
         --annotation "org.opencontainers.image.licenses=Apache-2.0" \
         "${repository}/${component}:${tag}" \
-        "${file}"
+        "${file}" \
+        2>&1 \
+			| tee /dev/stderr \
+			| grep -o 'sha256:[a-f0-9]\{64\}' \
+    )
+
+    cosign sign --yes "${repository}/${component}:${tag}@${digest}"
 }
 
 publish_oci "${SCRIPT_DIR}/lib/factory.wasm"


### PR DESCRIPTION
- publish dev builds from main branch
- sign published components with cosign
- drop cargo-component in favor of wasm-tools